### PR TITLE
Build NEPA lawn booking PWA with map-based quote estimation and SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# NEPA Grass Cutting — Website + Booking App (PWA)
+
+A fast, SEO-friendly starter for a **Northeast Pennsylvania** lawn care business where customers can:
+
+- get an instant quote based on measured yard area,
+- choose add-ons (weed whacking, edging, treatments),
+- book a date/time,
+- proceed to payment.
+
+## Temporary domain recommendation
+Use a temporary, SEO-friendly domain while validating:
+
+- `https://nepa-grasscutting-demo.pages.dev`
+
+Why this works:
+- includes regional keyword (`nepa`),
+- includes service intent (`grasscutting`),
+- fast global hosting on Cloudflare Pages.
+
+## Features
+
+- **SEO best practices** for local service pages:
+  - title/meta tuned to Northeast PA service intent
+  - canonical URL
+  - Open Graph + Twitter cards
+  - JSON-LD LocalBusiness schema
+- **Performance-focused implementation**:
+  - static HTML/CSS/JS (minimal JS)
+  - system font stack
+  - deferred scripts
+  - lazy map initialization
+  - service worker + web manifest for app installability
+- **Instant quote estimator**:
+  - Draw yard polygon on OpenStreetMap via Leaflet + Leaflet.draw
+  - Auto-calculate area in square feet
+  - Dynamic pricing with configurable add-ons
+- **Booking flow** with a checkout handoff button
+
+## Run locally
+
+```bash
+python -m http.server 8080
+# open http://localhost:8080
+```
+
+## Payment wiring (production)
+
+Replace `PAYMENT_URL` in `scripts/booking.js` with your Stripe Payment Link or hosted checkout URL.
+
+## Next production steps
+
+1. Connect to Stripe Checkout Sessions API (server-side) for dynamic totals.
+2. Save bookings in a DB (Supabase/Postgres/Firebase).
+3. Add technician dispatch logic and service-area geofencing for NEPA zip codes.
+4. Plug in Google Maps API if you prefer parcel overlays over OSM drawing.

--- a/app.webmanifest
+++ b/app.webmanifest
@@ -1,0 +1,9 @@
+{
+  "name": "NEPA Grass Cutting",
+  "short_name": "NEPA Lawn",
+  "start_url": "/booking.html",
+  "display": "standalone",
+  "background_color": "#f7faf7",
+  "theme_color": "#2f7a32",
+  "icons": []
+}

--- a/booking.html
+++ b/booking.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Book Lawn Service | NEPA Grass Cutting</title>
+    <meta
+      name="description"
+      content="Get an instant lawn mowing quote in Northeast PA, choose options, pick your date, and pay online."
+    />
+    <link rel="canonical" href="https://nepa-grasscutting-demo.pages.dev/booking.html" />
+    <link rel="stylesheet" href="/styles/site.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
+    />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.css"
+      crossorigin=""
+    />
+  </head>
+  <body>
+    <header class="shell hero">
+      <p class="eyebrow">Instant quote + online checkout</p>
+      <h1>Book your grass cutting service</h1>
+      <p>Draw your yard, choose service options, then schedule and pay.</p>
+    </header>
+
+    <main class="shell">
+      <section class="card">
+        <h2>1) Draw your yard</h2>
+        <p class="notice">Tip: Search your property, then use polygon tool to trace mowable area.</p>
+        <div id="map" aria-label="Yard measurement map"></div>
+        <p>Measured area: <strong id="areaSqft">0</strong> sq ft</p>
+      </section>
+
+      <section class="card">
+        <h2>2) Service details</h2>
+        <form id="bookingForm" class="form-grid">
+          <label>
+            Service address
+            <input required id="address" name="address" placeholder="123 Main St, Scranton, PA" />
+          </label>
+          <label>
+            Date
+            <input required id="date" name="date" type="date" />
+          </label>
+          <label>
+            Time window
+            <select id="time" name="time">
+              <option>8am - 10am</option>
+              <option>10am - 12pm</option>
+              <option>12pm - 2pm</option>
+              <option>2pm - 4pm</option>
+            </select>
+          </label>
+
+          <label><input type="checkbox" id="weedWhack" /> Weed whacking (+$18)</label>
+          <label><input type="checkbox" id="edging" /> Edging (+$12)</label>
+          <label><input type="checkbox" id="treatment" /> Basic treatment (+$35)</label>
+
+          <div>
+            <p>Estimated total</p>
+            <p id="quote" class="quote">$45.00</p>
+          </div>
+
+          <button class="btn btn-primary" type="submit">Continue to payment</button>
+        </form>
+      </section>
+    </main>
+
+    <footer class="shell footer">
+      <small>Need help? Call/text local support for Northeast PA routes.</small>
+    </footer>
+
+    <script defer src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script defer src="https://unpkg.com/leaflet-draw@1.0.4/dist/leaflet.draw.js"></script>
+    <script defer src="/scripts/booking.js"></script>
+    <script defer src="/scripts/pwa.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>NEPA Grass Cutting | Fast Lawn Mowing in Northeast Pennsylvania</title>
+    <meta
+      name="description"
+      content="Book lawn mowing in Northeast PA in minutes. Auto quotes by yard size, choose add-ons like weed whacking and treatments, and pay online."
+    />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="https://nepa-grasscutting-demo.pages.dev/" />
+
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="NEPA Grass Cutting | Book Online" />
+    <meta
+      property="og:description"
+      content="Instant lawn care quotes, easy booking, and online payment for Northeast Pennsylvania homeowners."
+    />
+    <meta property="og:url" content="https://nepa-grasscutting-demo.pages.dev/" />
+    <meta property="og:site_name" content="NEPA Grass Cutting" />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="NEPA Grass Cutting" />
+    <meta
+      name="twitter:description"
+      content="Auto yard-size quote + online booking for Northeast PA lawn mowing."
+    />
+
+    <link rel="manifest" href="/app.webmanifest" />
+    <link rel="stylesheet" href="/styles/site.css" />
+
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "LocalBusiness",
+        "name": "NEPA Grass Cutting",
+        "url": "https://nepa-grasscutting-demo.pages.dev",
+        "areaServed": ["Scranton", "Wilkes-Barre", "Pittston", "Northeast Pennsylvania"],
+        "serviceType": "Lawn mowing and yard maintenance",
+        "address": {
+          "@type": "PostalAddress",
+          "addressRegion": "PA",
+          "addressCountry": "US"
+        },
+        "hasOfferCatalog": {
+          "@type": "OfferCatalog",
+          "name": "Lawn Care Services",
+          "itemListElement": [
+            { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Grass Cutting" } },
+            { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Weed Whacking" } },
+            { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Lawn Treatment" } }
+          ]
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <header class="shell hero">
+      <p class="eyebrow">Northeast Pennsylvania Lawn Care</p>
+      <h1>Book grass cutting online in under 2 minutes.</h1>
+      <p>
+        Instant quote by yard size, smart add-ons, and secure payment—built for homeowners in
+        Scranton, Wilkes-Barre, and surrounding NEPA communities.
+      </p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="/booking.html">Get quote & book</a>
+        <a class="btn btn-secondary" href="#how">How it works</a>
+      </div>
+    </header>
+
+    <main class="shell">
+      <section id="how" class="grid-3">
+        <article>
+          <h2>1) Measure yard</h2>
+          <p>Draw your lawn area on map for an automatic square-foot estimate.</p>
+        </article>
+        <article>
+          <h2>2) Pick add-ons</h2>
+          <p>Add weed whacking, edging, and treatment options at checkout.</p>
+        </article>
+        <article>
+          <h2>3) Book & pay</h2>
+          <p>Select date/time, pay online, and we dispatch a nearby crew.</p>
+        </article>
+      </section>
+
+      <section class="card">
+        <h2>Built for NEPA SEO growth</h2>
+        <ul>
+          <li>Service pages targeting “grass cutting Northeast PA” intent</li>
+          <li>LocalBusiness structured data</li>
+          <li>Fast-loading static architecture for strong Core Web Vitals</li>
+        </ul>
+      </section>
+    </main>
+
+    <footer class="shell footer">
+      <small>© 2026 NEPA Grass Cutting — Temporary demo domain in use.</small>
+    </footer>
+
+    <script defer src="/scripts/pwa.js"></script>
+  </body>
+</html>

--- a/scripts/booking.js
+++ b/scripts/booking.js
@@ -1,0 +1,132 @@
+const BASE_RATE_PER_SQFT = 0.015;
+const MIN_CUT_PRICE = 45;
+const ADD_ONS = {
+  weedWhack: 18,
+  edging: 12,
+  treatment: 35,
+};
+
+const PAYMENT_URL = "https://buy.stripe.com/test_6oE5kCdemoReplaceMe";
+
+const areaEl = document.getElementById("areaSqft");
+const quoteEl = document.getElementById("quote");
+const form = document.getElementById("bookingForm");
+const addOnInputs = ["weedWhack", "edging", "treatment"].map((id) => document.getElementById(id));
+
+let areaSqft = 0;
+
+const formatMoney = (n) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(n);
+
+function calculateQuote() {
+  const cut = Math.max(MIN_CUT_PRICE, areaSqft * BASE_RATE_PER_SQFT);
+  const addOnTotal = addOnInputs
+    .filter((input) => input.checked)
+    .reduce((sum, input) => sum + ADD_ONS[input.id], 0);
+  return cut + addOnTotal;
+}
+
+function renderQuote() {
+  const total = calculateQuote();
+  quoteEl.textContent = formatMoney(total);
+}
+
+addOnInputs.forEach((i) => i.addEventListener("change", renderQuote));
+
+form.addEventListener("submit", (e) => {
+  e.preventDefault();
+
+  const payload = {
+    address: document.getElementById("address").value,
+    date: document.getElementById("date").value,
+    time: document.getElementById("time").value,
+    areaSqft,
+    addOns: addOnInputs.filter((input) => input.checked).map((input) => input.id),
+    estimate: calculateQuote(),
+  };
+
+  localStorage.setItem("pendingBooking", JSON.stringify(payload));
+
+  if (PAYMENT_URL.includes("ReplaceMe")) {
+    alert("Connect Stripe payment URL in scripts/booking.js before going live.");
+    return;
+  }
+
+  window.location.href = PAYMENT_URL;
+});
+
+function initMap() {
+  if (!window.L) return;
+
+  const map = L.map("map", { scrollWheelZoom: false }).setView([41.40897, -75.66241], 14);
+
+  L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+    maxZoom: 19,
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+  }).addTo(map);
+
+  const drawn = new L.FeatureGroup();
+  map.addLayer(drawn);
+
+  const drawControl = new L.Control.Draw({
+    draw: {
+      polyline: false,
+      rectangle: true,
+      circle: false,
+      marker: false,
+      circlemarker: false,
+      polygon: {
+        allowIntersection: false,
+        showArea: true,
+      },
+    },
+    edit: {
+      featureGroup: drawn,
+    },
+  });
+
+  map.addControl(drawControl);
+
+  map.on(L.Draw.Event.CREATED, (event) => {
+    drawn.clearLayers();
+    const layer = event.layer;
+    drawn.addLayer(layer);
+    updateArea(layer);
+  });
+
+  map.on(L.Draw.Event.EDITED, (event) => {
+    event.layers.eachLayer((layer) => updateArea(layer));
+  });
+
+  map.on(L.Draw.Event.DELETED, () => {
+    areaSqft = 0;
+    areaEl.textContent = "0";
+    renderQuote();
+  });
+}
+
+function updateArea(layer) {
+  const latLngs = layer.getLatLngs?.();
+  if (!latLngs?.length) return;
+
+  const ring = Array.isArray(latLngs[0]) ? latLngs[0] : latLngs;
+  const points = ring.map((p) => [p.lat, p.lng]);
+
+  let areaMeters = 0;
+  for (let i = 0; i < points.length; i += 1) {
+    const [lat1, lon1] = points[i];
+    const [lat2, lon2] = points[(i + 1) % points.length];
+    areaMeters += ((lon2 - lon1) * Math.PI) / 180 *
+      (2 + Math.sin((lat1 * Math.PI) / 180) + Math.sin((lat2 * Math.PI) / 180));
+  }
+  areaMeters = Math.abs(areaMeters * 6378137 * 6378137 / 2.0);
+
+  areaSqft = Math.round(areaMeters * 10.7639);
+  areaEl.textContent = areaSqft.toLocaleString("en-US");
+  renderQuote();
+}
+
+window.addEventListener("load", () => {
+  renderQuote();
+  requestIdleCallback ? requestIdleCallback(initMap) : setTimeout(initMap, 200);
+});

--- a/scripts/pwa.js
+++ b/scripts/pwa.js
@@ -1,0 +1,7 @@
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", () => {
+    navigator.serviceWorker.register("/service-worker.js").catch(() => {
+      // no-op in local/dev restrictions
+    });
+  });
+}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,10 @@
+const CACHE_NAME = "nepa-lawn-v1";
+const ASSETS = ["/", "/index.html", "/booking.html", "/styles/site.css", "/scripts/booking.js", "/scripts/pwa.js", "/app.webmanifest"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)));
+});
+
+self.addEventListener("fetch", (event) => {
+  event.respondWith(caches.match(event.request).then((cached) => cached || fetch(event.request)));
+});

--- a/styles/site.css
+++ b/styles/site.css
@@ -1,0 +1,117 @@
+:root {
+  --bg: #f7faf7;
+  --text: #132218;
+  --accent: #2f7a32;
+  --accent-2: #1e5f25;
+  --card: #ffffff;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.5;
+}
+
+.shell {
+  width: min(1024px, 92vw);
+  margin: 0 auto;
+}
+
+.hero {
+  padding: 4rem 0 2rem;
+}
+
+.eyebrow {
+  font-weight: 600;
+  color: var(--accent-2);
+}
+
+h1 {
+  font-size: clamp(2rem, 3vw, 3rem);
+  line-height: 1.15;
+}
+
+.hero-cta {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+.btn {
+  text-decoration: none;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  display: inline-block;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: white;
+}
+
+.btn-secondary {
+  border: 1px solid var(--accent);
+  color: var(--accent);
+}
+
+.grid-3 {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  margin: 2rem 0;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.04);
+}
+
+.footer {
+  padding: 2rem 0 3rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+label {
+  display: grid;
+  gap: 0.4rem;
+  font-weight: 600;
+}
+
+input, select {
+  border: 1px solid #c9d6ca;
+  border-radius: 8px;
+  padding: 0.55rem 0.7rem;
+}
+
+.quote {
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--accent-2);
+}
+
+#map {
+  height: 360px;
+  width: 100%;
+  border-radius: 12px;
+  border: 1px solid #d5ddd5;
+}
+
+.notice {
+  background: #edf8ee;
+  border-left: 4px solid var(--accent);
+  padding: 0.75rem 0.9rem;
+  border-radius: 8px;
+}


### PR DESCRIPTION
### Motivation
- Provide a fast, SEO-focused landing site and installable web app so Northeast Pennsylvania homeowners can get instant yard-based quotes, book a date/time, and pay online.
- Use a lightweight static-first architecture and PWA features to optimize performance and Core Web Vitals for local-service search intent.

### Description
- Added a SEO-ready landing page `index.html` with meta tags, canonical URL, social cards, and `LocalBusiness` JSON-LD for NEPA targeting.\
- Implemented a booking page `booking.html` that lets users draw their yard on a map (Leaflet + `leaflet-draw`) and shows measured area and an instant quote.\
- Added `scripts/booking.js` to calculate price from measured square footage plus configurable add-ons, persist a pending booking to `localStorage`, and perform a payment handoff via a `PAYMENT_URL` placeholder.\
- Added PWA support with `app.webmanifest`, `service-worker.js` for basic offline caching, `scripts/pwa.js` to register the service worker, site styles in `styles/site.css`, and usage/documentation in `README.md` including a temporary demo domain recommendation.\
- Attempted to use the `skill-installer` to fetch extra performance skills but the remote listing was blocked by the environment (network `403`), so performance best practices were applied directly (deferred scripts, lazy map init, minimal JS, caching). 

### Testing
- Ran `node --check scripts/booking.js` which succeeded.\
- Ran `node --check scripts/pwa.js` which succeeded.\
- Ran `node --check service-worker.js` which succeeded.\
- Attempted `python /opt/codex/skills/.system/skill-installer/scripts/list-skills.py --format json` which failed due to a network proxy `403 Forbidden`, so no remote skill was installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae05968808321bafda067371f5908)